### PR TITLE
fixed warning

### DIFF
--- a/includes/metabox/init.php
+++ b/includes/metabox/init.php
@@ -743,7 +743,7 @@ class cmb_Meta_Box {
 		elseif ( is_string( $meta_box['pages'] ) )
 			$type = $meta_box['pages'];
 		// if it's an array of one, extract it
-		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] === 1 ) )
+		elseif ( is_array( $meta_box['pages'] ) && count($meta_box['pages']) === 1 )
 			$type = is_string( end( $meta_box['pages'] ) ) ? end( $meta_box['pages'] ) : false;
 
 		if ( !$type )


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable in /Users/toddmcbrearty/Code/lovestoriestv1/wp-content/plugins/arconix-faq/includes/metabox/init.php on line 746


this was actually an error. the function was counting the whole condition
`count($meta_box['pages'] === 1)`

I've updated it to
`count($meta_box['pages']) === 1`